### PR TITLE
fix: move conditional icon theming functionality to tabs

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -18,14 +18,16 @@ import {
   ConnectScreenConnected,
 } from '@apollosproject/ui-connected';
 import { checkOnboardingStatusAndNavigate } from '@apollosproject/ui-onboarding';
+import { Appearance } from 'react-native';
 
 const HeaderLogo = () => {
   const theme = useTheme();
+  const deviceColorScheme = Appearance.getColorScheme();
   return (
     <Icon
       name="brand-icon"
       size={theme.sizing.baseUnit * 1.5}
-      fill={theme.colors.primary}
+      fill={deviceColorScheme === 'light' ? theme.colors.primary : '#ffffff'}
     />
   );
 };

--- a/theme.js
+++ b/theme.js
@@ -2,7 +2,6 @@ import ApollosConfig from '@apollosproject/config';
 import Svg, { Path } from 'react-native-svg';
 import FRAGMENTS from '@apollosproject/ui-fragments';
 import { makeIcon } from '@apollosproject/ui-kit';
-import { Appearance } from 'react-native';
 
 const THEME = {
   colors: { primary: '#1C1C1C', secondary: '#00B3E3', tertiary: '#EC5840' },
@@ -12,8 +11,6 @@ const THEME = {
 
 const ICONS = {
   BrandIcon: makeIcon(({ size = 32, fill, ...otherProps } = {}) => {
-    const deviceColorScheme = Appearance.getColorScheme();
-    fill = deviceColorScheme === 'light' ? '#1C1C1C' : '#ffffff';
     return (
       <Svg
         width={75}


### PR DESCRIPTION
Per your recommendation [here](https://github.com/Differential/cityfirst-apollos/commit/ed8bd7b04f1e574dff4ff095ef96778fb5c0bb79#commitcomment-69374809), this should be fixed now